### PR TITLE
Normalize all Elm keywords

### DIFF
--- a/src/Graphqelm/Generator/Normalize.elm
+++ b/src/Graphqelm/Generator/Normalize.elm
@@ -1,14 +1,46 @@
-module Graphqelm.Generator.Normalize exposing (capitalized, decapitalized)
+module Graphqelm.Generator.Normalize exposing (capitalized, decapitalized, elmKeywords)
 
 import Char
 import Regex
 import String.Extra
 
 
+{-| Taken from <https://github.com/elm-lang/elm-compiler/blob/master/src/Parse/Primitives/Keyword.hs>
+-}
+elmKeywords : List String
+elmKeywords =
+    [ "type"
+    , "alias"
+    , "port"
+    , "if"
+    , "then"
+    , "else"
+    , "case"
+    , "of"
+    , "let"
+    , "in"
+    , "infix"
+    , "left"
+    , "right"
+    , "non"
+    , "module"
+    , "import"
+    , "exposing"
+    , "as"
+    , "where"
+    , "effect"
+    , "command"
+    , "subscription"
+    , "true"
+    , "false"
+    , "null"
+    ]
+
+
 normalizeIfElmReserved : String -> String
 normalizeIfElmReserved name =
-    if name == "type" then
-        "type_"
+    if List.member name elmKeywords then
+        name ++ "_"
     else
         name
 

--- a/tests/Generator/NormalizeTests.elm
+++ b/tests/Generator/NormalizeTests.elm
@@ -7,15 +7,11 @@ import Test exposing (Test, describe, only, test)
 
 all : Test
 all =
-    describe "normalize"
+    describe "normalize" <|
         [ test "leaves valid names untouched" <|
             \() ->
                 Normalize.decapitalized "validCamelCaseName"
                     |> Expect.equal "validCamelCaseName"
-        , test "type field name" <|
-            \() ->
-                Normalize.decapitalized "type"
-                    |> Expect.equal "type_"
         , test "leaves valid snake_case names untouched" <|
             \() ->
                 Normalize.decapitalized "year_budget"
@@ -61,3 +57,11 @@ all =
                 Normalize.decapitalized "________x"
                     |> Expect.equal "x________"
         ]
+            ++ List.map
+                (\keyword ->
+                    test (keyword ++ " field name") <|
+                        \() ->
+                            Normalize.decapitalized keyword
+                                |> Expect.equal (keyword ++ "_")
+                )
+                Normalize.elmKeywords


### PR DESCRIPTION
Here is an update the normalizes all the Elm keywords, as listed in the Elm compilers Parser code.

I updated the unit tests to test all keywords, but I am not sure if I like this style, where the test and the code basically share the same data, and therefor testing the whole list bring little extra value over testing a single entry.